### PR TITLE
feat: verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1242,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +1751,33 @@ dependencies = [
  "sha2 0.10.9",
  "sha3 0.10.8",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
@@ -2730,6 +2787,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glam"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3279,6 +3342,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
 
 [[package]]
+name = "jiff"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3492,6 +3596,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3651,6 +3764,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3801,6 +3923,12 @@ dependencies = [
  "env_logger",
  "log",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "p256"
@@ -4015,6 +4143,15 @@ name = "portable-atomic"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f59e70c4aef1e55797c2e8fd94a4f2a973fc972cfde0e0b05f683667b0cd39dd"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -4573,6 +4710,12 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -5596,6 +5739,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5835,9 +5988,12 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "bytes",
+ "color-eyre",
  "criterion 0.5.1",
  "digest 0.11.0-rc.4",
+ "eyre",
  "hex",
+ "jiff",
  "once_cell",
  "opentimestamps",
  "paste",
@@ -5849,6 +6005,7 @@ dependencies = [
  "sha2 0.11.0-rc.3",
  "sha3 0.11.0-rc.3",
  "thiserror 2.0.17",
+ "tokio",
  "tracing",
  "uts-contracts",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ eyre = "0.6"
 futures = "0.3"
 hex = "0.4"
 itoa = "1.0"
+jiff = "0.2.20"
 once_cell = { version = "1.21", default-features = false }
 paste = "1.0"
 regex = "1.12"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,6 +14,11 @@ name = "uts-info"
 path = "src/bin/uts_info.rs"
 required-features = ["std"]
 
+[[bin]]
+name = "uts-verifier"
+path = "src/bin/uts_verifier.rs"
+required-features = ["verifier-bin-deps"]
+
 [dependencies]
 alloy-chains = { workspace = true }
 alloy-primitives = { workspace = true }
@@ -22,8 +27,11 @@ alloy-rpc-types-eth = { workspace = true, optional = true }
 alloy-sol-types = { workspace = true, optional = true }
 auto_impl.workspace = true
 bytes = { workspace = true, optional = true }
+color-eyre = { workspace = true, optional = true }
 digest.workspace = true
+eyre = { workspace = true, optional = true }
 hex.workspace = true
+jiff = { workspace = true, optional = true }
 once_cell = { workspace = true, features = ["alloc"] }
 paste.workspace = true
 ripemd.workspace = true
@@ -33,6 +41,7 @@ sha1.workspace = true
 sha2.workspace = true
 sha3.workspace = true
 thiserror.workspace = true
+tokio = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 uts-contracts = { workspace = true, optional = true }
 
@@ -44,6 +53,16 @@ serde = ["dep:serde", "dep:serde_with", "serde/derive", "serde_with/hex"]
 std = []
 tracing = ["dep:tracing"]
 verifier = []
+
+verifier-bin-deps = [
+  "dep:eyre",
+  "dep:tokio",
+  "dep:color-eyre",
+  "dep:jiff",
+  "std",
+  "ethereum-uts-verifier",
+  "tokio/full",
+]
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/core/src/bin/uts_verifier.rs
+++ b/crates/core/src/bin/uts_verifier.rs
@@ -1,0 +1,138 @@
+use alloy_provider::ProviderBuilder;
+use digest::{Digest, DynDigest};
+use jiff::{Timestamp, tz::TimeZone};
+use std::{
+    env, fs,
+    io::{BufReader, Read},
+    process,
+};
+use uts_core::{
+    codec::{
+        Decode, Reader, VersionedProof,
+        v1::{
+            Attestation, DetachedTimestamp, EthereumUTSAttestation, PendingAttestation, opcode::*,
+        },
+    },
+    utils::Hexed,
+    verifier::{AttestationVerifier, EthereumUTSVerifier},
+};
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
+
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <file> <ots> [eth provider url]", args[0]);
+        process::exit(1);
+    }
+
+    let mut fh = BufReader::new(if args.len() >= 3 {
+        fs::File::open(&args[2])?
+    } else {
+        fs::File::open(format!("{}.ots", &args[1]))?
+    });
+    let timestamp = VersionedProof::<DetachedTimestamp>::decode(&mut Reader(&mut fh))?.proof;
+
+    let digest_header = timestamp.header();
+    let mut hasher = match digest_header.kind().tag() {
+        SHA1 => Box::new(sha1::Sha1::new()) as Box<dyn DynDigest>,
+        RIPEMD160 => Box::new(ripemd::Ripemd160::new()) as Box<dyn DynDigest>,
+        SHA256 => Box::new(sha2::Sha256::new()) as Box<dyn DynDigest>,
+        KECCAK256 => Box::new(sha3::Keccak256::new()) as Box<dyn DynDigest>,
+        _ => {
+            eprintln!("Unsupported digest type: {}", digest_header.kind());
+            process::exit(1);
+        }
+    };
+
+    let mut file = BufReader::new(fs::File::open(&args[1])?);
+    let mut buffer = [0u8; 64 * 1024]; // 64KB buffer
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+    let expected = hasher.finalize();
+
+    if *expected != *digest_header.digest() {
+        eprintln!(
+            "Digest mismatch! Expected: {}, Found: {}",
+            Hexed(&expected),
+            Hexed(digest_header.digest())
+        );
+        process::exit(1);
+    }
+    eprintln!("Digest matches: {}", Hexed(&expected));
+
+    timestamp.try_finalize()?;
+
+    for attestation in timestamp.attestations() {
+        if attestation.tag == PendingAttestation::TAG {
+            continue; // skip pending attestations
+        }
+
+        if attestation.tag == EthereumUTSAttestation::TAG {
+            let eth_attestation = EthereumUTSAttestation::from_raw(&attestation)?;
+            eprintln!("Attested by {eth_attestation}");
+            let provider_url = if args.len() >= 4 {
+                &*args[3]
+            } else {
+                match eth_attestation.chain.id() {
+                    1 => "https://0xrpc.io/eth",
+                    11155111 => "https://0xrpc.io/sep",
+                    534352 => "https://rpc.scroll.io",
+                    534351 => "https://sepolia-rpc.scroll.io",
+                    _ => panic!("Unsupported chain: {}", eth_attestation.chain),
+                }
+            };
+            let provider = ProviderBuilder::new().connect(provider_url).await?;
+            let verifier = EthereumUTSVerifier::new(provider).await?;
+            let result = verifier
+                .verify(&eth_attestation, attestation.value().unwrap())
+                .await?;
+            if let Some(block_number) = result.block_number {
+                if let Some(block_hash) = result.block_hash {
+                    eprintln!("\tblock: #{block_number} {block_hash}");
+                } else {
+                    eprintln!("\tblock: {block_number}");
+                }
+            }
+            if let Some(log_index) = result.log_index {
+                eprintln!("\tlog index: {log_index}");
+            }
+            if let Some(transaction_hash) = result.transaction_hash {
+                if let Some((_, etherscan_url)) = eth_attestation.chain.etherscan_urls() {
+                    eprintln!("\ttransaction: {etherscan_url}/tx/{transaction_hash}");
+                } else {
+                    eprintln!("\ttransaction hash: {transaction_hash}");
+                }
+            }
+
+            if let Some((_, etherscan_url)) = eth_attestation.chain.etherscan_urls() {
+                eprintln!(
+                    "\tuts contract: {etherscan_url}/address/{}",
+                    result.inner.address
+                );
+            } else {
+                eprintln!("\tuts contract: {}", result.inner.address);
+            }
+            if let Some((_, etherscan_url)) = eth_attestation.chain.etherscan_urls() {
+                eprintln!(
+                    "\ttx sender: {etherscan_url}/address/{}",
+                    result.inner.sender
+                );
+            } else {
+                eprintln!("\ttx sender: {}", result.inner.sender);
+            }
+            let ts = Timestamp::from_second(result.inner.timestamp.to())?;
+            let zdt = ts.to_zoned(TimeZone::system());
+            eprintln!("\ttime attested: {zdt}");
+            eprintln!("\tmerkle root: {}", result.inner.root);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/core/src/codec/v1/attestation.rs
+++ b/crates/core/src/codec/v1/attestation.rs
@@ -90,6 +90,12 @@ impl<A: Allocator> RawAttestation<A> {
     pub fn allocator(&self) -> &A {
         self.data.allocator()
     }
+
+    /// Returns the cached value for verifying the attestation, if it exists.
+    #[inline]
+    pub fn value(&self) -> Option<&[u8]> {
+        self.value.get().map(|v| v.as_slice())
+    }
 }
 
 pub trait Attestation<'a>: Sized {

--- a/crates/core/src/codec/v1/detached_timestamp.rs
+++ b/crates/core/src/codec/v1/detached_timestamp.rs
@@ -4,6 +4,7 @@ use crate::codec::{
 };
 use alloc::alloc::{Allocator, Global};
 use core::{fmt, fmt::Formatter};
+use std::ops::Deref;
 
 /// A file containing a timestamp for another file
 /// Contains a timestamp, along with a header and the digest of the file.
@@ -108,6 +109,14 @@ impl<A: Allocator + Clone> DetachedTimestamp<A> {
     /// Returns an error if the timestamp cannot be finalized.
     pub fn try_finalize(&self) -> Result<(), FinalizationError> {
         self.timestamp.try_finalize(self.header.digest())
+    }
+}
+
+impl Deref for DetachedTimestamp {
+    type Target = Timestamp;
+
+    fn deref(&self) -> &Self::Target {
+        &self.timestamp
     }
 }
 

--- a/crates/core/src/codec/v1/timestamp.rs
+++ b/crates/core/src/codec/v1/timestamp.rs
@@ -144,6 +144,12 @@ impl<A: Allocator> Timestamp<A> {
     pub fn is_finalized(&self) -> bool {
         self.input().is_some()
     }
+
+    /// Iterates over all attestations in this timestamp.
+    #[inline]
+    pub fn attestations(&self) -> AttestationIter<'_, A> {
+        AttestationIter { stack: vec![self] }
+    }
 }
 
 impl<A: Allocator + Clone> Timestamp<A> {
@@ -280,5 +286,28 @@ impl<A: Allocator> MayHaveInput for Step<A> {
     #[inline]
     fn input(&self) -> Option<&[u8]> {
         self.input.get().map(|v| v.as_slice())
+    }
+}
+
+#[must_use = "AttestationIter is an iterator, it does nothing unless consumed"]
+pub struct AttestationIter<'a, A: Allocator> {
+    stack: Vec<&'a Timestamp<A>>,
+}
+
+impl<'a, A: Allocator> Iterator for AttestationIter<'a, A> {
+    type Item = &'a RawAttestation<A>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(ts) = self.stack.pop() {
+            match ts {
+                Timestamp::Step(step) => {
+                    for next in step.next().iter().rev() {
+                        self.stack.push(next);
+                    }
+                }
+                Timestamp::Attestation(attestation) => return Some(attestation),
+            }
+        }
+        None
     }
 }


### PR DESCRIPTION
```
(.venv) > $ cargo run -p uts-core --bin uts-verifier --features="verifier-bin-deps" -- UniversalTimestamps.json
Finished `dev` profile [optimized + debuginfo] target(s) in 0.16s
     Running `/Users/hhq/workspace/uts/target/debug/uts-verifier UniversalTimestamps.json`
Digest matches: d9d6f102d1a671c1158f977401e7ad0d4df6115933eaecaa0884c2c372548b29
Attested by UTS on chain scroll-sepolia at block #16862454(no extra metadata)
        block: #16862454 0x5c78535c855c1ecd0657212a9621546a2fdfed6dea06591fa90b12e228f2b2c5
        log index: 0
        transaction: https://sepolia.scrollscan.com/tx/0xac79cc7087923f45441775e59c308d56f7cfe21f4b42eb4ef99cd63586b9e44b
        uts contract: https://sepolia.scrollscan.com/address/0xceB7a9E77bd00D0391349B9bC989167cAB5e35e7
        tx sender: https://sepolia.scrollscan.com/address/0x609523B36a35F826F4d52e500c3f8ACd59Edc635
        time attested: 2026-02-21T14:08:23+08:00[Asia/Hong_Kong]
        merkle root: 0x7eb06fdbe20e402a8125775968899b4ab87b9af1c20a81d4af8d5bb0c96d7c64
```